### PR TITLE
Add exporter version information to the user agent string.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setuptools.setup(
 version = "{version!s}"
 """,
     },
-    install_requires=("opencensus~=0.7", "newrelic-telemetry-sdk~=0.2"),
+    install_requires=("opencensus~=0.7", "newrelic-telemetry-sdk>=0.2.1,<0.3"),
 )

--- a/src/opencensus_ext_newrelic/stats.py
+++ b/src/opencensus_ext_newrelic/stats.py
@@ -20,6 +20,11 @@ from newrelic_telemetry_sdk import MetricClient, GaugeMetric, CountMetric
 
 import logging
 
+try:
+    from opencensus_ext_newrelic.version import version as __version__
+except ImportError:  # pragma: no cover
+    __version__ = "unknown"  # pragma: no cover
+
 _logger = logging.getLogger(__name__)
 COUNT_AGGREGATION_TYPES = {aggregation.CountAggregation, aggregation.SumAggregation}
 
@@ -55,7 +60,8 @@ class NewRelicStatsExporter(object):
     """
 
     def __init__(self, insert_key, service_name, host=None, interval=5):
-        self.client = MetricClient(insert_key=insert_key, host=host)
+        client = self.client = MetricClient(insert_key=insert_key, host=host)
+        client.add_version_info("NewRelic-Python-OpenCensus", __version__)
         self.views = {}
         self.count_values = {}
 

--- a/src/opencensus_ext_newrelic/trace.py
+++ b/src/opencensus_ext_newrelic/trace.py
@@ -19,6 +19,11 @@ from newrelic_telemetry_sdk import Span, SpanClient
 
 import logging
 
+try:
+    from opencensus_ext_newrelic.version import version as __version__
+except ImportError:  # pragma: no cover
+    __version__ = "unknown"  # pragma: no cover
+
 _logger = logging.getLogger(__name__)
 
 
@@ -68,7 +73,8 @@ class NewRelicTraceExporter(base_exporter.Exporter):
 
     def __init__(self, insert_key, service_name, host=None, transport=DefaultTransport):
         self._common = {"attributes": {"service.name": service_name}}
-        self.client = SpanClient(insert_key=insert_key, host=host)
+        client = self.client = SpanClient(insert_key=insert_key, host=host)
+        client.add_version_info("NewRelic-Python-OpenCensus", __version__)
         self._transport = transport(self)
 
     def emit(self, span_datas):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -114,8 +114,13 @@ def test_stats(stats_exporter, ensure_utf8, tag_values):
 
     # Send metrics to exporter
     response = stats_exporter.export_metrics(metrics)
-    data = json.loads(ensure_utf8(response.request.body))
 
+    # Verify headers
+    user_agent = response.request.headers["user-agent"]
+    assert user_agent.split()[-1].startswith("NewRelic-Python-OpenCensus/")
+
+    # Verify payload
+    data = json.loads(ensure_utf8(response.request.body))
     common = data[0]["common"]
     assert len(common) == 2
     assert common["interval.ms"] == stats_exporter.interval * 1000

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -47,6 +47,12 @@ def test_trace(trace_exporter, ensure_utf8):
     timestamp = 1557533268000
 
     response = trace_exporter.export([SPAN_DATA])
+
+    # Verify headers
+    user_agent = response.request.headers["user-agent"]
+    assert user_agent.split()[-1].startswith("NewRelic-Python-OpenCensus/")
+
+    # Verify payload
     data = json.loads(ensure_utf8(response.request.body))
     assert len(data) == 1
     data = data[0]


### PR DESCRIPTION
This PR implements https://github.com/newrelic/newrelic-exporter-specs/pull/22 for the New Relic Python OpenCensus exporter. This metadata may be used by customers to explore where their data is generated.