### PR TITLE
Remove redundant language name from user agent string. Resolves: #5

### DIFF
--- a/src/opencensus_ext_newrelic/stats.py
+++ b/src/opencensus_ext_newrelic/stats.py
@@ -61,7 +61,7 @@ class NewRelicStatsExporter(object):
 
     def __init__(self, insert_key, service_name, host=None, interval=5):
         client = self.client = MetricClient(insert_key=insert_key, host=host)
-        client.add_version_info("NewRelic-Python-OpenCensus", __version__)
+        client.add_version_info("NewRelic-OpenCensus-Exporter", __version__)
         self.views = {}
         self.count_values = {}
 

--- a/src/opencensus_ext_newrelic/trace.py
+++ b/src/opencensus_ext_newrelic/trace.py
@@ -74,7 +74,7 @@ class NewRelicTraceExporter(base_exporter.Exporter):
     def __init__(self, insert_key, service_name, host=None, transport=DefaultTransport):
         self._common = {"attributes": {"service.name": service_name}}
         client = self.client = SpanClient(insert_key=insert_key, host=host)
-        client.add_version_info("NewRelic-Python-OpenCensus", __version__)
+        client.add_version_info("NewRelic-OpenCensus-Exporter", __version__)
         self._transport = transport(self)
 
     def emit(self, span_datas):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -117,7 +117,7 @@ def test_stats(stats_exporter, ensure_utf8, tag_values):
 
     # Verify headers
     user_agent = response.request.headers["user-agent"]
-    assert user_agent.split()[-1].startswith("NewRelic-Python-OpenCensus/")
+    assert user_agent.split()[-1].startswith("NewRelic-OpenCensus-Exporter/")
 
     # Verify payload
     data = json.loads(ensure_utf8(response.request.body))

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -50,7 +50,7 @@ def test_trace(trace_exporter, ensure_utf8):
 
     # Verify headers
     user_agent = response.request.headers["user-agent"]
-    assert user_agent.split()[-1].startswith("NewRelic-Python-OpenCensus/")
+    assert user_agent.split()[-1].startswith("NewRelic-OpenCensus-Exporter/")
 
     # Verify payload
     data = json.loads(ensure_utf8(response.request.body))


### PR DESCRIPTION
See newrelic/newrelic-exporter-specs#25 for the spec change.

The Telemetry SDK already includes the language in its part of the user-agent. It was deemed redundant to put the language name in the user agent string again.