### PR TITLE
export summary metrics for distribution views

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -155,6 +155,8 @@ def test_stats(stats_exporter, ensure_utf8, tag_values):
         else:
             assert metric_data["type"] == "summary"
 
+        assert len(metric_data) <= 5
+
         expected_tags.remove(metric_data["attributes"]["tag"])
         if not expected_tags:
             remaining_tags.pop(view.name)


### PR DESCRIPTION
Currently, we do no sort of exporting for distribution type metrics. This PR aims to export a rudimentary set of data for a distribution view.

This isn't meant to replace whatever full featured histogram support we aim to provide in the future, but is instead aimed at getting around dropping data on the floor entirely in the meantime.

Spec discussion for this can be found here: https://github.com/newrelic/newrelic-exporter-specs/pull/34