### PR TITLE
Make client port configurable.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setuptools.setup(
 version = "{version!s}"
 """,
     },
-    install_requires=("opencensus~=0.7", "newrelic-telemetry-sdk>=0.2.1,<0.3"),
+    install_requires=("opencensus~=0.7", "newrelic-telemetry-sdk>=0.3.0,<0.4"),
 )

--- a/src/opencensus_ext_newrelic/stats.py
+++ b/src/opencensus_ext_newrelic/stats.py
@@ -61,7 +61,7 @@ class NewRelicStatsExporter(object):
         >>> stats_exporter.stop()
     """
 
-    def __init__(self, insert_key, service_name, interval=5, host=None, port=None):
+    def __init__(self, insert_key, service_name, interval=5, host=None, port=443):
         client = self.client = MetricClient(insert_key=insert_key, host=host, port=port)
         client.add_version_info("NewRelic-OpenCensus-Exporter", __version__)
         self.views = {}

--- a/src/opencensus_ext_newrelic/stats.py
+++ b/src/opencensus_ext_newrelic/stats.py
@@ -48,6 +48,8 @@ class NewRelicStatsExporter(object):
     :type interval: int or float
     :param host: (optional) Override the host for the API endpoint.
     :type host: str
+    :param port: (optional) Override the port for the API endpoint.
+    :type port: int
 
     Usage::
 
@@ -59,8 +61,8 @@ class NewRelicStatsExporter(object):
         >>> stats_exporter.stop()
     """
 
-    def __init__(self, insert_key, service_name, host=None, interval=5):
-        client = self.client = MetricClient(insert_key=insert_key, host=host)
+    def __init__(self, insert_key, service_name, interval=5, host=None, port=None):
+        client = self.client = MetricClient(insert_key=insert_key, host=host, port=port)
         client.add_version_info("NewRelic-OpenCensus-Exporter", __version__)
         self.views = {}
         self.count_values = {}

--- a/src/opencensus_ext_newrelic/trace.py
+++ b/src/opencensus_ext_newrelic/trace.py
@@ -51,8 +51,6 @@ class NewRelicTraceExporter(base_exporter.Exporter):
     :param service_name: (optional) The name of the entity to report spans
         into. Defaults to "Python Application".
     :type service_name: str
-    :param host: (optional) Override the host for the API endpoint.
-    :type host: str
     :param transport: (optional) Class for creating new transport objects. It
         should extend from the base_exporter
         :class:`opencensus.common.transports.base.Transport` type and implement
@@ -60,6 +58,10 @@ class NewRelicTraceExporter(base_exporter.Exporter):
         an async transport sending data every 5 seconds. The other option is
         :class:`opencensus.common.transports.async.AsyncTransport`.
     :type transport: :class:`opencensus.common.transports.base.Transport`
+    :param host: (optional) Override the host for the API endpoint.
+    :type host: str
+    :param port: (optional) Override the port for the API endpoint.
+    :type host: int
 
     Usage::
 
@@ -71,9 +73,11 @@ class NewRelicTraceExporter(base_exporter.Exporter):
         >>> trace_exporter.stop()
     """
 
-    def __init__(self, insert_key, service_name, host=None, transport=DefaultTransport):
+    def __init__(
+        self, insert_key, service_name, transport=DefaultTransport, host=None, port=None
+    ):
         self._common = {"attributes": {"service.name": service_name}}
-        client = self.client = SpanClient(insert_key=insert_key, host=host)
+        client = self.client = SpanClient(insert_key=insert_key, host=host, port=port)
         client.add_version_info("NewRelic-OpenCensus-Exporter", __version__)
         self._transport = transport(self)
 

--- a/src/opencensus_ext_newrelic/trace.py
+++ b/src/opencensus_ext_newrelic/trace.py
@@ -74,7 +74,7 @@ class NewRelicTraceExporter(base_exporter.Exporter):
     """
 
     def __init__(
-        self, insert_key, service_name, transport=DefaultTransport, host=None, port=None
+        self, insert_key, service_name, transport=DefaultTransport, host=None, port=443
     ):
         self._common = {"attributes": {"service.name": service_name}}
         client = self.client = SpanClient(insert_key=insert_key, host=host, port=port)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import functools
 import pytest
+import zlib
 from newrelic_telemetry_sdk.client import HTTPResponse
 from urllib3 import HTTPConnectionPool
 
@@ -17,6 +18,10 @@ def _ensure_utf8(s):
         except Exception:
             return
     return s
+
+
+def _decompress_data(d):
+    return _ensure_utf8(zlib.decompress(d, 31))
 
 
 class Request(object):
@@ -59,8 +64,8 @@ def _http_response(status_code):
 
 
 @pytest.fixture
-def ensure_utf8():
-    return _ensure_utf8
+def decompress_payload():
+    return _decompress_data
 
 
 @pytest.fixture

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -10,6 +10,7 @@ from opencensus.stats import view as view_module
 from opencensus.stats import view_data as view_data_module
 from opencensus.stats import metric_utils
 from opencensus_ext_newrelic import NewRelicStatsExporter
+from newrelic_telemetry_sdk import MetricClient
 
 
 # The latency in milliseconds
@@ -309,6 +310,26 @@ def test_default_exporter_values(insert_key):
     exporter._thread.cancel()
 
     assert exporter.interval == 5
+    assert exporter.client._pool.host == MetricClient.HOST
+    assert exporter.client._pool.port == 443
+
+
+def test_override_exporter_values(insert_key):
+    host = "non-default-host"
+    interval = 30
+    port = 8080
+    exporter = NewRelicStatsExporter(
+        insert_key,
+        service_name="Python Application",
+        interval=interval,
+        host=host,
+        port=port,
+    )
+    exporter._thread.cancel()
+
+    assert exporter.interval == interval
+    assert exporter.client._pool.host == host
+    assert exporter.client._pool.port == port
 
 
 def test_invalid_point(stats_exporter, caplog):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -46,7 +46,7 @@ for field in SpanData._fields:
 SPAN_DATA = SpanData(**SPAN_DATA)
 
 
-def test_trace(trace_exporter, ensure_utf8):
+def test_trace(trace_exporter, decompress_payload):
     duration = 1000
     timestamp = int((TEST_TIME - datetime(1970, 1, 1)).total_seconds() * 1000.0)
 
@@ -57,7 +57,7 @@ def test_trace(trace_exporter, ensure_utf8):
     assert user_agent.split()[-1].startswith("NewRelic-OpenCensus-Exporter/")
 
     # Verify payload
-    data = json.loads(ensure_utf8(response.request.body))
+    data = json.loads(decompress_payload(response.request.body))
     assert len(data) == 1
     data = data[0]
     spans, common = data["spans"], data["common"]


### PR DESCRIPTION
This PR allows users to override the default port for the span and metric clients.